### PR TITLE
Fix asyncio event loop error on Windows

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+import sys
 
 from bot.bot import main as run_bot
 from db.database import init_db
@@ -11,7 +12,7 @@ logging.basicConfig(
 logger = logging.getLogger(__name__)
 
 
-def main():
+async def main():
     """Основная функция для запуска бота."""
     try:
         logger.info("Инициализация базы данных...")
@@ -19,8 +20,8 @@ def main():
         logger.info("База данных инициализирована.")
 
         logger.info("Запуск бота...")
-        # Используем asyncio.run() для запуска асинхронной функции run_bot
-        asyncio.run(run_bot())
+        # Используем await для запуска асинхронной функции run_bot
+        await run_bot()
 
     except Exception as e:
         logger.critical(f"Произошла критическая ошибка на верхнем уровне: {e}", exc_info=True)
@@ -29,4 +30,7 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    # На Windows может потребоваться другая политика событий для корректной работы asyncio
+    if sys.platform == "win32":
+        asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
+    asyncio.run(main())


### PR DESCRIPTION
The application was crashing on startup with a `RuntimeError: Cannot close a running event loop`, specifically in Windows environments.

This was caused by an incompatibility between the `python-telegram-bot` library and the default Windows `ProactorEventLoop`.

The fix is two-fold:
1.  The main application entry point in `main.py` is refactored to be fully asynchronous, using a single top-level `asyncio.run()`.
2.  A check is added to `main.py` to detect if the OS is Windows. If so, the asyncio event loop policy is changed to `WindowsSelectorEventLoopPolicy`, which is compatible with the library and resolves the conflict.