### PR TITLE
This commit introduces the 'Update resume' feature.

### DIFF
--- a/bot/bot.py
+++ b/bot/bot.py
@@ -29,6 +29,7 @@ from bot.handlers.analysis import (
     generate_tech_plan_handler,
 )
 from bot.handlers.menu import (
+    update_resume_handler,
     upload_vacancy_handler,
     select_vacancy_handler,
     vacancy_selected_handler,
@@ -67,6 +68,7 @@ def create_application() -> Application:
                 generate_hr_plan_handler,
                 generate_tech_plan_handler,
                 # Действия из меню (из menu.py)
+                update_resume_handler,
                 upload_vacancy_handler,
                 select_vacancy_handler,
                 vacancy_selected_handler,

--- a/bot/handlers/start.py
+++ b/bot/handlers/start.py
@@ -48,7 +48,7 @@ async def start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
 
         await update.message.reply_text(
             messages.MAIN_MENU_MESSAGE.format(resume_title=resume.title, vacancy_count=vacancy_count),
-            reply_markup=keyboards.main_menu_keyboard(vacancy_count)
+            reply_markup=keyboards.main_menu_keyboard(vacancy_count=vacancy_count, has_resume=True)
         )
         return MAIN_MENU
 

--- a/bot/handlers/vacancy.py
+++ b/bot/handlers/vacancy.py
@@ -78,7 +78,10 @@ async def process_vacancy_text(update: Update, context: ContextTypes.DEFAULT_TYP
         vacancies = crud.get_user_vacancies(db, user_id=user.id)
         await message.reply_text(
             messages.MAIN_MENU_MESSAGE.format(vacancy_count=len(vacancies)),
-            reply_markup=keyboards.main_menu_keyboard(len(vacancies))
+            reply_markup=keyboards.main_menu_keyboard(
+                vacancy_count=len(vacancies),
+                has_resume=True
+            )
         )
         return MAIN_MENU
     finally:

--- a/bot/keyboards.py
+++ b/bot/keyboards.py
@@ -3,7 +3,7 @@ from db.models import Vacancy
 from typing import List
 
 # --- Main Menu Keyboards ---
-def main_menu_keyboard(vacancy_count: int) -> InlineKeyboardMarkup:
+def main_menu_keyboard(vacancy_count: int, has_resume: bool) -> InlineKeyboardMarkup:
     """Генерирует клавиатуру для главного меню."""
     buttons = [
         [InlineKeyboardButton("Анализ резюме/вакансии", callback_data="analyze_match")],
@@ -15,6 +15,9 @@ def main_menu_keyboard(vacancy_count: int) -> InlineKeyboardMarkup:
         buttons.append([InlineKeyboardButton(f"Выбрать другую вакансию ({vacancy_count})", callback_data="select_vacancy")])
 
     buttons.append([InlineKeyboardButton("Загрузить новую вакансию", callback_data="upload_vacancy")])
+    if has_resume:
+        buttons.append([InlineKeyboardButton("Обновить резюме", callback_data="update_resume")])
+
     return InlineKeyboardMarkup(buttons)
 
 # --- Vacancy Selection Keyboard ---

--- a/tests/test_handlers/test_menu.py
+++ b/tests/test_handlers/test_menu.py
@@ -1,0 +1,36 @@
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from telegram import Update
+from telegram.ext import ContextTypes
+
+from bot.handlers.menu import update_resume_request
+from bot.handlers.resume import AWAITING_RESUME_UPLOAD
+from bot import messages, keyboards
+
+
+@pytest.mark.anyio
+@patch('bot.handlers.menu.keyboards', new_callable=MagicMock)
+async def test_update_resume_request(mock_keyboards):
+    """
+    Тестирует обработчик 'update_resume_request'.
+    Проверяет, что бот отправляет правильное сообщение и переходит в состояние ожидания резюме.
+    """
+    # --- Mocks Setup ---
+    mock_keyboards.cancel_keyboard.return_value = "cancel_keyboard_markup"
+
+    update = AsyncMock(spec=Update)
+    query = AsyncMock()
+    update.callback_query = query
+    context = MagicMock(spec=ContextTypes.DEFAULT_TYPE)
+
+    # --- Call ---
+    result = await update_resume_request(update, context)
+
+    # --- Assertions ---
+    assert result == AWAITING_RESUME_UPLOAD
+    query.answer.assert_called_once()
+    query.edit_message_text.assert_called_once_with(
+        messages.ASK_FOR_RESUME,
+        reply_markup="cancel_keyboard_markup"
+    )

--- a/tests/test_handlers/test_start.py
+++ b/tests/test_handlers/test_start.py
@@ -108,4 +108,5 @@ async def test_start_with_resume_and_vacancies(mock_get_db, mock_crud, mock_keyb
     assert result == MAIN_MENU
     expected_message = messages.MAIN_MENU_MESSAGE.format(resume_title="My Awesome Resume", vacancy_count=1)
     update.message.reply_text.assert_any_call(expected_message, reply_markup="main_menu_markup")
+    mock_keyboards.main_menu_keyboard.assert_called_once_with(vacancy_count=1, has_resume=True)
     assert context.user_data['selected_vacancy_id'] == mock_vacancy.id


### PR DESCRIPTION
A new 'Update resume' button is added to the main menu, which is only visible to users who have already uploaded a resume.

When a user clicks this button, they are prompted to upload a new resume. The existing resume is then replaced with the new one.

The implementation includes:
- A new handler for the 'Update resume' button.
- Updates to the main menu keyboard to conditionally display the button.
- Updates to all call sites of the main menu keyboard to provide the necessary information.
- New tests to ensure the new functionality works as expected and does not introduce any regressions.