### PR TITLE
refactor: Use action registry for AI calls

### DIFF
--- a/ai/actions.py
+++ b/ai/actions.py
@@ -1,0 +1,24 @@
+# ai/actions.py
+"""
+Реестр действий AI, который сопоставляет имена действий с методами клиента AI и другой метаинформацией.
+"""
+from bot import messages
+
+ACTION_REGISTRY = {
+    "analyze_match": {
+        "ai_method_name": "analyze_match",
+        "response_header": messages.ANALYSIS_COMPLETE,
+    },
+    "generate_letter": {
+        "ai_method_name": "generate_cover_letter",
+        "response_header": messages.COVER_LETTER_COMPLETE,
+    },
+    "generate_hr_plan": {
+        "ai_method_name": "generate_hr_call_plan",
+        "response_header": messages.HR_CALL_PLAN_COMPLETE,
+    },
+    "generate_tech_plan": {
+        "ai_method_name": "generate_tech_interview_plan",
+        "response_header": messages.TECH_INTERVIEW_PLAN_COMPLETE,
+    },
+}


### PR DESCRIPTION
Refactors the AI action handling in `bot/handlers/analysis.py` to be more scalable and maintainable.

- Replaced the `if/elif` chain in `_call_ai_for_action` with a dynamic dispatch mechanism.
- Introduced an `ACTION_REGISTRY` in a new `ai/actions.py` file to map action strings to AI client methods and response headers.
- This eliminates the need to modify the handler logic when adding new AI-powered analysis actions.
- Updated tests to reflect the new implementation, ensuring the dynamic method dispatch is correctly mocked and verified.