### PR TITLE
Fix vacancy upload flow and resume handling

### DIFF
--- a/bot/bot.py
+++ b/bot/bot.py
@@ -17,17 +17,11 @@ from bot.handlers.states import MAIN_MENU, UPDATE_RESUME
 logger = logging.getLogger(__name__)
 
 
-def create_application() -> Application:
+def create_main_conv_handler() -> ConversationHandler:
     """
-    Создает и настраивает экземпляр приложения Telegram с вложенными ConversationHandler.
+    Создает и возвращает главный ConversationHandler, управляющий диалогом.
     """
-    if not TELEGRAM_BOT_TOKEN:
-        raise ValueError("Токен TELEGRAM_BOT_TOKEN не найден в .env файле!")
-
-    application = Application.builder().token(TELEGRAM_BOT_TOKEN).build()
-
-    # Главный обработчик диалога, который управляет всем состоянием бота
-    conv_handler = ConversationHandler(
+    return ConversationHandler(
         entry_points=[onboarding_handler()],
         states={
             MAIN_MENU: [main_menu_handler()],
@@ -42,6 +36,16 @@ def create_application() -> Application:
         allow_reentry=True,
     )
 
+
+def create_application() -> Application:
+    """
+    Создает и настраивает экземпляр приложения Telegram с вложенными ConversationHandler.
+    """
+    if not TELEGRAM_BOT_TOKEN:
+        raise ValueError("Токен TELEGRAM_BOT_TOKEN не найден в .env файле!")
+
+    application = Application.builder().token(TELEGRAM_BOT_TOKEN).build()
+    conv_handler = create_main_conv_handler()
     application.add_handler(conv_handler)
 
     return application

--- a/bot/handlers/onboarding.py
+++ b/bot/handlers/onboarding.py
@@ -9,16 +9,22 @@ from telegram.ext import (
 )
 
 from bot.handlers.common import cancel, global_fallback_handler
-from bot.handlers.states import AWAITING_RESUME_UPLOAD, MAIN_MENU
+from bot.handlers.states import AWAITING_RESUME_UPLOAD, MAIN_MENU, AWAITING_VACANCY_UPLOAD
 from bot.handlers.resume import (
     resume_file_handler,
     resume_url_handler,
     fallback_resume_handler,
     handle_invalid_resume_input,
 )
+from bot.handlers.vacancy import (
+    vacancy_file_handler,
+    vacancy_url_handler,
+    fallback_vacancy_handler,
+)
 from bot.handlers.start import start
 
 logger = logging.getLogger(__name__)
+
 
 def onboarding_handler() -> ConversationHandler:
     """
@@ -32,6 +38,11 @@ def onboarding_handler() -> ConversationHandler:
                 resume_url_handler,
                 MessageHandler(filters.PHOTO, handle_invalid_resume_input),
                 fallback_resume_handler,
+            ],
+            AWAITING_VACANCY_UPLOAD: [
+                vacancy_file_handler,
+                vacancy_url_handler,
+                fallback_vacancy_handler,
             ],
         },
         fallbacks=[

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,5 @@
 import pytest
-import os
 from unittest.mock import MagicMock, AsyncMock
-
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 from telegram import Update
@@ -9,8 +7,6 @@ from telegram.ext import ContextTypes
 
 from db.models import Base
 
-# Используем in-memory SQLite базу данных для тестов, чтобы не затрагивать основную БД
-# и обеспечить изоляцию тестов.
 TEST_DATABASE_URL = "sqlite:///:memory:"
 
 
@@ -19,19 +15,13 @@ def db_session():
     """
     Фикстура pytest для создания новой сессии БД для каждой тестовой функции.
     """
-    # Создаем движок и таблицы для тестовой БД
     engine = create_engine(TEST_DATABASE_URL, connect_args={"check_same_thread": False})
     Base.metadata.create_all(bind=engine)
-
-    # Создаем фабрику сессий
     TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
-
     db = TestingSessionLocal()
     try:
-        # Передаем сессию в тестовую функцию
         yield db
     finally:
-        # Закрываем сессию и удаляем все таблицы после завершения теста
         db.close()
         Base.metadata.drop_all(bind=engine)
 
@@ -42,17 +32,14 @@ def update_mock():
     update = MagicMock(spec=Update)
     update.effective_chat.id = 12345
 
-    # Создаем единый мок для message и effective_message
     message_mock = AsyncMock()
     message_mock.reply_text = AsyncMock()
     update.message = message_mock
     update.effective_message = message_mock
 
-    # Мокаем callback_query
     callback_query_mock = AsyncMock()
     callback_query_mock.answer = AsyncMock()
     callback_query_mock.edit_message_text = AsyncMock()
-    # Добавляем .message к .callback_query для соответствия реальному объекту
     callback_query_mock.message = AsyncMock()
     callback_query_mock.message.reply_text = AsyncMock()
     update.callback_query = callback_query_mock

--- a/tests/test_handlers/test_conversation_flow.py
+++ b/tests/test_handlers/test_conversation_flow.py
@@ -1,0 +1,59 @@
+import pytest
+from unittest.mock import patch, AsyncMock, MagicMock
+from telegram import Document
+
+from bot.handlers.start import start
+from bot.handlers.resume import handle_resume_file
+from bot.handlers.vacancy import handle_vacancy_file
+from bot.handlers.states import AWAITING_RESUME_UPLOAD, AWAITING_VACANCY_UPLOAD, MAIN_MENU
+from db import crud, models
+
+@pytest.mark.anyio
+@patch("bot.handlers.vacancy.show_main_menu", new_callable=AsyncMock)
+@patch("bot.handlers.resume.show_main_menu", new_callable=AsyncMock)
+async def test_conversation_flow(
+    mock_resume_show_main_menu,
+    mock_vacancy_show_main_menu,
+    db_session,
+    update_mock,
+    context_mock,
+):
+    """
+    Tests the conversation flow by calling handlers in sequence.
+    """
+    async def mock_process_document(update, context, db, user_id, text, source, doc_type):
+        if doc_type == "resume":
+            # In a real scenario, the document service would create the resume.
+            # Here, we simulate this by creating it directly.
+            crud.create_resume(db, user_id, "test.txt", source, "Test Resume")
+            return True, "Test Resume"
+        elif doc_type == "vacancy":
+            crud.create_vacancy(db, user_id, "test.txt", source, "Test Vacancy")
+            return True, "Test Vacancy"
+        return False, None
+
+    with patch("bot.handlers.resume.process_document", new=mock_process_document):
+        with patch("bot.handlers.vacancy.process_document", new=mock_process_document):
+            # 1. /start (no resume) -> AWAITING_RESUME_UPLOAD
+            state = await start(update_mock, context_mock)
+            assert state == AWAITING_RESUME_UPLOAD
+
+            # 2. Upload resume -> AWAITING_VACANCY_UPLOAD
+            mock_document = MagicMock(spec=Document)
+            mock_document.file_name = "resume.txt"
+            mock_file = AsyncMock()
+            mock_file.download_as_bytearray.return_value = b"Resume text"
+            mock_document.get_file.return_value = mock_file
+            update_mock.message.document = mock_document
+
+            state = await handle_resume_file(update_mock, context_mock)
+            assert state == AWAITING_VACANCY_UPLOAD
+
+            # 3. Upload vacancy -> MAIN_MENU
+            mock_document.file_name = "vacancy.txt"
+            mock_file.download_as_bytearray.return_value = b"Vacancy text"
+            update_mock.message.document = mock_document
+
+            state = await handle_vacancy_file(update_mock, context_mock)
+            assert state == MAIN_MENU
+            mock_vacancy_show_main_menu.assert_called_once()


### PR DESCRIPTION
This commit fixes a bug where the bot would get stuck after a user uploaded a resume and was prompted to upload a vacancy. The `AWAITING_VACANCY_UPLOAD` state was missing from the `onboarding_handler`'s state machine.

This commit also fixes a bug in the resume handler where it would always transition to the main menu after a successful resume upload, instead of prompting for a vacancy if none existed.

I attempted to write an integration test to cover this conversation flow, but was unsuccessful after multiple attempts. The existing unit tests pass.