### PR TITLE
fix(tests): Repair test_conversation_flow and resolve circular import

### DIFF
--- a/bot/handlers/main_menu_helpers.py
+++ b/bot/handlers/main_menu_helpers.py
@@ -5,7 +5,7 @@ from telegram.ext import ContextTypes
 from bot import messages, keyboards
 from db import crud
 from db.database import get_db
-from .resume import AWAITING_RESUME_UPLOAD
+from .states import AWAITING_RESUME_UPLOAD
 
 logger = logging.getLogger(__name__)
 

--- a/tests/test_handlers/test_conversation_flow.py
+++ b/tests/test_handlers/test_conversation_flow.py
@@ -8,10 +8,17 @@ from bot.handlers.vacancy import handle_vacancy_file
 from bot.handlers.states import AWAITING_RESUME_UPLOAD, AWAITING_VACANCY_UPLOAD, MAIN_MENU
 from db import crud, models
 
+
 @pytest.mark.anyio
 @patch("bot.handlers.vacancy.show_main_menu", new_callable=AsyncMock)
 @patch("bot.handlers.resume.show_main_menu", new_callable=AsyncMock)
+@patch("bot.handlers.start.get_db")
+@patch("bot.handlers.resume.get_db")
+@patch("bot.handlers.vacancy.get_db")
 async def test_conversation_flow(
+    mock_vacancy_get_db,
+    mock_resume_get_db,
+    mock_start_get_db,
     mock_resume_show_main_menu,
     mock_vacancy_show_main_menu,
     db_session,
@@ -21,39 +28,46 @@ async def test_conversation_flow(
     """
     Tests the conversation flow by calling handlers in sequence.
     """
+    # Mock get_db to be a generator that yields the test session
+    def db_session_generator():
+        yield db_session
+
+    mock_start_get_db.side_effect = db_session_generator
+    mock_resume_get_db.side_effect = db_session_generator
+    mock_vacancy_get_db.side_effect = db_session_generator
+
     async def mock_process_document(update, context, db, user_id, text, source, doc_type):
         if doc_type == "resume":
-            # In a real scenario, the document service would create the resume.
-            # Here, we simulate this by creating it directly.
-            crud.create_resume(db, user_id, "test.txt", source, "Test Resume")
+            crud.create_resume(db, user_id, file_path="test.txt", source=source, title="Test Resume")
             return True, "Test Resume"
         elif doc_type == "vacancy":
-            crud.create_vacancy(db, user_id, "test.txt", source, "Test Vacancy")
+            crud.create_vacancy(db, user_id, file_path="test.txt", source=source, title="Test Vacancy")
             return True, "Test Vacancy"
         return False, None
 
-    with patch("bot.handlers.resume.process_document", new=mock_process_document):
-        with patch("bot.handlers.vacancy.process_document", new=mock_process_document):
-            # 1. /start (no resume) -> AWAITING_RESUME_UPLOAD
-            state = await start(update_mock, context_mock)
-            assert state == AWAITING_RESUME_UPLOAD
+    with patch("bot.handlers.resume.process_document", new=mock_process_document), \
+         patch("bot.handlers.vacancy.process_document", new=mock_process_document):
 
-            # 2. Upload resume -> AWAITING_VACANCY_UPLOAD
-            mock_document = MagicMock(spec=Document)
-            mock_document.file_name = "resume.txt"
-            mock_file = AsyncMock()
-            mock_file.download_as_bytearray.return_value = b"Resume text"
-            mock_document.get_file.return_value = mock_file
-            update_mock.message.document = mock_document
+        # 1. /start (no resume) -> AWAITING_RESUME_UPLOAD
+        state = await start(update_mock, context_mock)
+        assert state == AWAITING_RESUME_UPLOAD
 
-            state = await handle_resume_file(update_mock, context_mock)
-            assert state == AWAITING_VACANCY_UPLOAD
+        # 2. Upload resume -> AWAITING_VACANCY_UPLOAD
+        mock_document = MagicMock(spec=Document)
+        mock_document.file_name = "resume.txt"
+        mock_file = AsyncMock()
+        mock_file.download_as_bytearray.return_value = b"Resume text"
+        mock_document.get_file.return_value = mock_file
+        update_mock.message.document = mock_document
 
-            # 3. Upload vacancy -> MAIN_MENU
-            mock_document.file_name = "vacancy.txt"
-            mock_file.download_as_bytearray.return_value = b"Vacancy text"
-            update_mock.message.document = mock_document
+        state = await handle_resume_file(update_mock, context_mock)
+        assert state == AWAITING_VACANCY_UPLOAD
 
-            state = await handle_vacancy_file(update_mock, context_mock)
-            assert state == MAIN_MENU
-            mock_vacancy_show_main_menu.assert_called_once()
+        # 3. Upload vacancy -> MAIN_MENU
+        mock_document.file_name = "vacancy.txt"
+        mock_file.download_as_bytearray.return_value = b"Vacancy text"
+        update_mock.message.document = mock_document
+
+        state = await handle_vacancy_file(update_mock, context_mock)
+        assert state == MAIN_MENU
+        mock_vacancy_show_main_menu.assert_called_once()


### PR DESCRIPTION
The `test_conversation_flow.py` test was failing due to two issues:

1. A circular import between `main_menu_helpers.py` and `resume.py`. This was resolved by importing the state constant from `states.py` in `main_menu_helpers.py`.

2. Incorrect mocking of the database session. The application handlers expect `get_db()` to be a generator that yields a database session. The test was incorrectly providing a raw session object, causing a `TypeError`.

This commit fixes the test by:
- Modifying the mock for `get_db()` to be a generator that yields the test database session, using `side_effect`.
- Patching `get_db` in each handler module (`start`, `resume`, `vacancy`) to ensure they use the test's in-memory database.