### PR TITLE
Fix unresponsive menu buttons by refactoring ConversationHandler

### DIFF
--- a/bot/bot.py
+++ b/bot/bot.py
@@ -10,7 +10,7 @@ from telegram.ext import (
 from config import TELEGRAM_BOT_TOKEN
 from bot.handlers.common import cancel, global_fallback_handler
 from bot.handlers.onboarding import onboarding_handler
-from bot.handlers.main_menu import main_menu_handler
+from bot.handlers.main_menu import main_menu_handlers
 from bot.handlers.states import MAIN_MENU, UPDATE_RESUME
 
 
@@ -24,7 +24,7 @@ def create_main_conv_handler() -> ConversationHandler:
     return ConversationHandler(
         entry_points=[onboarding_handler()],
         states={
-            MAIN_MENU: [main_menu_handler()],
+            MAIN_MENU: main_menu_handlers(),
             UPDATE_RESUME: [onboarding_handler()],
         },
         fallbacks=[

--- a/bot/handlers/main_menu.py
+++ b/bot/handlers/main_menu.py
@@ -21,38 +21,15 @@ from bot.handlers.vacancy_management import vacancy_handler
 logger = logging.getLogger(__name__)
 
 
-def main_menu_handler() -> ConversationHandler:
+def main_menu_handlers() -> list:
     """
-    Обработчик для главного меню.
+    Возвращает список обработчиков для главного меню.
     """
-    return ConversationHandler(
-        entry_points=[
-            # Этот обработчик не имеет своей точки входа,
-            # так как в него попадают из других обработчиков
-        ],
-        states={
-            MAIN_MENU: [
-                analyze_match_handler,
-                generate_letter_handler,
-                generate_hr_plan_handler,
-                generate_tech_plan_handler,
-                update_resume_handler,
-                vacancy_handler(),
-            ]
-        },
-        fallbacks=[
-            CallbackQueryHandler(cancel, pattern="^cancel_action$"),
-            MessageHandler(filters.TEXT & ~filters.COMMAND, global_fallback_handler),
-        ],
-        per_user=True,
-        per_chat=True,
-        allow_reentry=True,
-        map_to_parent={
-            # Позволяет вернуться к этому состоянию из дочерних обработчиков
-            MAIN_MENU: MAIN_MENU,
-            # Переход в состояние обновления резюме
-            UPDATE_RESUME: UPDATE_RESUME,
-            # При отмене из дочерних, возвращаемся в главное меню
-            ConversationHandler.END: MAIN_MENU,
-        },
-    )
+    return [
+        analyze_match_handler,
+        generate_letter_handler,
+        generate_hr_plan_handler,
+        generate_tech_plan_handler,
+        update_resume_handler,
+        vacancy_handler(),
+    ]


### PR DESCRIPTION
The main menu buttons were not working because the CallbackQueryHandlers were nested inside a ConversationHandler that was never entered.

This commit refactors the handler structure by removing the nested ConversationHandler. The `main_menu_handlers` function now returns a list of handlers that are directly used in the main ConversationHandler. This ensures that the CallbackQueryHandlers are correctly registered and can respond to button clicks.