### PR TITLE
Fix MarkdownV2 Escaping in Telegram Handlers

### DIFF
--- a/bot/handlers/analysis.py
+++ b/bot/handlers/analysis.py
@@ -7,6 +7,7 @@ from telegram.constants import ParseMode
 
 from .resume import MAIN_MENU
 from bot import messages
+from bot.utils import escape_markdown_v2
 from db import crud
 from db.database import get_db
 from ai.client import get_ai_client
@@ -26,10 +27,15 @@ async def _perform_analysis(update: Update, context: ContextTypes.DEFAULT_TYPE, 
     vacancy_id = context.user_data.get('selected_vacancy_id')
 
     if not vacancy_id:
-        await query.message.reply_text(text=messages.CHOOSE_VACANCY_FOR_ACTION, parse_mode=ParseMode.MARKDOWN_V2)
+        await query.message.reply_text(
+            text=escape_markdown_v2(messages.CHOOSE_VACANCY_FOR_ACTION), parse_mode=ParseMode.MARKDOWN_V2
+        )
         return MAIN_MENU
 
-    await query.message.reply_text(text="⏳ Выполняю ваш запрос... Это может занять некоторое время.", parse_mode=ParseMode.MARKDOWN_V2)
+    await query.message.reply_text(
+        text=escape_markdown_v2("⏳ Выполняю ваш запрос... Это может занять некоторое время."),
+        parse_mode=ParseMode.MARKDOWN_V2,
+    )
 
     db_session_gen = get_db()
     db = next(db_session_gen)
@@ -39,7 +45,7 @@ async def _perform_analysis(update: Update, context: ContextTypes.DEFAULT_TYPE, 
         vacancy = crud.get_vacancy_by_id(db, vacancy_id=vacancy_id)
 
         if not resume or not vacancy:
-            await query.message.reply_text(text=messages.ERROR_MESSAGE, parse_mode=ParseMode.MARKDOWN_V2)
+            await query.message.reply_text(text=escape_markdown_v2(messages.ERROR_MESSAGE), parse_mode=ParseMode.MARKDOWN_V2)
             return MAIN_MENU
 
         # Проверяем кэш
@@ -51,13 +57,17 @@ async def _perform_analysis(update: Update, context: ContextTypes.DEFAULT_TYPE, 
                     response_text = f.read()
                 action_details = ACTION_REGISTRY.get(action)
                 if not action_details:
-                    await query.message.reply_text(text=messages.NOT_IMPLEMENTED, parse_mode=ParseMode.MARKDOWN_V2)
+                    await query.message.reply_text(
+                        text=escape_markdown_v2(messages.NOT_IMPLEMENTED), parse_mode=ParseMode.MARKDOWN_V2
+                    )
                     return MAIN_MENU
                 header = action_details["response_header"]
                 message_text = f"{header}\n\n{response_text}"
-                message_text_parts = [message_text[i:i+4000] for i in range(0, len(message_text), 4000)]
+                message_text_parts = [message_text[i:i + 4000] for i in range(0, len(message_text), 4000)]
                 for message_text_part in message_text_parts:
-                    await query.message.reply_text(text=message_text_part, parse_mode=ParseMode.MARKDOWN_V2)
+                    await query.message.reply_text(
+                        text=escape_markdown_v2(message_text_part), parse_mode=ParseMode.MARKDOWN_V2
+                    )
                 return MAIN_MENU
             except FileNotFoundError:
                 logger.warning(f"Файл для кэшированного результата не найден: {cached_result.file_path}")
@@ -71,7 +81,7 @@ async def _perform_analysis(update: Update, context: ContextTypes.DEFAULT_TYPE, 
                 vacancy_text = f.read()
         except FileNotFoundError:
             logger.error(f"Файл резюме или вакансии не найден для пользователя {chat_id}.")
-            await query.message.reply_text(text=messages.ERROR_MESSAGE, parse_mode=ParseMode.MARKDOWN_V2)
+            await query.message.reply_text(text=escape_markdown_v2(messages.ERROR_MESSAGE), parse_mode=ParseMode.MARKDOWN_V2)
             return MAIN_MENU
 
         # Получаем клиент AI
@@ -80,7 +90,9 @@ async def _perform_analysis(update: Update, context: ContextTypes.DEFAULT_TYPE, 
         # Вызов AI и логирование
         response, header = _call_ai_for_action(ai_client, action, resume_text, vacancy_text)
         if not response:
-            await query.message.reply_text(text=messages.NOT_IMPLEMENTED, parse_mode=ParseMode.MARKDOWN_V2)
+            await query.message.reply_text(
+                text=escape_markdown_v2(messages.NOT_IMPLEMENTED), parse_mode=ParseMode.MARKDOWN_V2
+            )
             return MAIN_MENU
 
         response_text = response.get("text", "Не удалось получить ответ от AI.")
@@ -90,7 +102,9 @@ async def _perform_analysis(update: Update, context: ContextTypes.DEFAULT_TYPE, 
             logger.warning(f"Действие '{action}' не вернуло текст от AI. Ответ: {response}")
             # Отправляем сообщение об ошибке, если его еще не было
             if "error" in response:
-                await query.message.reply_text(text=messages.ERROR_MESSAGE, parse_mode=ParseMode.MARKDOWN_V2)
+                await query.message.reply_text(
+                    text=escape_markdown_v2(messages.ERROR_MESSAGE), parse_mode=ParseMode.MARKDOWN_V2
+                )
             return MAIN_MENU
 
         # Сохранение результата анализа
@@ -124,13 +138,13 @@ async def _perform_analysis(update: Update, context: ContextTypes.DEFAULT_TYPE, 
         )
 
         message_text = f"{header}\n\n{response_text}"
-        message_text_parts = [message_text[i:i+4000] for i in range(0, len(message_text), 4000)]
+        message_text_parts = [message_text[i:i + 4000] for i in range(0, len(message_text), 4000)]
         for message_text_part in message_text_parts:
-            await query.message.reply_text(text=message_text_part, parse_mode=ParseMode.MARKDOWN_V2)
+            await query.message.reply_text(text=escape_markdown_v2(message_text_part), parse_mode=ParseMode.MARKDOWN_V2)
 
     except Exception as e:
         logger.error(f"Ошибка во время выполнения действия '{action}' для пользователя {chat_id}: {e}", exc_info=True)
-        await query.message.reply_text(text=messages.ERROR_MESSAGE, parse_mode=ParseMode.MARKDOWN_V2)
+        await query.message.reply_text(text=escape_markdown_v2(messages.ERROR_MESSAGE), parse_mode=ParseMode.MARKDOWN_V2)
     finally:
         db.close()
 

--- a/bot/handlers/start.py
+++ b/bot/handlers/start.py
@@ -6,6 +6,7 @@ from telegram.constants import ParseMode
 from db.database import get_db
 from db import crud
 from bot import messages, keyboards
+from bot.utils import escape_markdown_v2
 from bot.handlers.states import AWAITING_RESUME_UPLOAD, AWAITING_VACANCY_UPLOAD, MAIN_MENU
 from .main_menu_helpers import show_main_menu
 
@@ -30,15 +31,28 @@ async def start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
 
         # 1. Если нет резюме, просим загрузить
         if not resume:
-            await update.message.reply_text(messages.WELCOME_MESSAGE, parse_mode=ParseMode.MARKDOWN_V2)
-            await update.message.reply_text(messages.ASK_FOR_RESUME, reply_markup=keyboards.cancel_keyboard(), parse_mode=ParseMode.MARKDOWN_V2)
+            await update.message.reply_text(
+                escape_markdown_v2(messages.WELCOME_MESSAGE), parse_mode=ParseMode.MARKDOWN_V2
+            )
+            await update.message.reply_text(
+                escape_markdown_v2(messages.ASK_FOR_RESUME),
+                reply_markup=keyboards.cancel_keyboard(),
+                parse_mode=ParseMode.MARKDOWN_V2,
+            )
             return AWAITING_RESUME_UPLOAD
 
         # 2. Если есть резюме, но нет вакансий
         vacancies = crud.get_user_vacancies(db, user_id=user.id)
         if not vacancies:
-            await update.message.reply_text(messages.MAIN_MENU_NO_VACANCIES.format(resume_title=resume.title), parse_mode=ParseMode.MARKDOWN_V2)
-            await update.message.reply_text(messages.ASK_FOR_VACANCY, reply_markup=keyboards.cancel_keyboard(), parse_mode=ParseMode.MARKDOWN_V2)
+            await update.message.reply_text(
+                escape_markdown_v2(messages.MAIN_MENU_NO_VACANCIES.format(resume_title=resume.title)),
+                parse_mode=ParseMode.MARKDOWN_V2,
+            )
+            await update.message.reply_text(
+                escape_markdown_v2(messages.ASK_FOR_VACANCY),
+                reply_markup=keyboards.cancel_keyboard(),
+                parse_mode=ParseMode.MARKDOWN_V2,
+            )
             return AWAITING_VACANCY_UPLOAD
 
         # 3. Если все есть, переходим в главное меню

--- a/bot/handlers/vacancy.py
+++ b/bot/handlers/vacancy.py
@@ -10,6 +10,7 @@ from telegram.ext import (
 from bot.handlers.states import MAIN_MENU, AWAITING_VACANCY_UPLOAD
 from .main_menu_helpers import show_main_menu
 from bot import messages, keyboards
+from bot.utils import escape_markdown_v2
 from db import crud
 from db.database import get_db
 from scraper.hh_scraper import scrape_hh_url
@@ -24,7 +25,7 @@ async def _process_and_reply(update: Update, context: ContextTypes.DEFAULT_TYPE,
     """
     chat_id = update.effective_chat.id
     message = update.effective_message
-    await message.reply_text(messages.VACANCY_PROCESSING, parse_mode=ParseMode.MARKDOWN_V2)
+    await message.reply_text(escape_markdown_v2(messages.VACANCY_PROCESSING), parse_mode=ParseMode.MARKDOWN_V2)
 
     db_session_gen = get_db()
     db = next(db_session_gen)
@@ -41,12 +42,20 @@ async def _process_and_reply(update: Update, context: ContextTypes.DEFAULT_TYPE,
         )
 
         if success:
-            await message.reply_text(messages.VACANCY_UPLOADED_SUCCESS, parse_mode=ParseMode.MARKDOWN_V2)
+            await message.reply_text(
+                escape_markdown_v2(messages.VACANCY_UPLOADED_SUCCESS), parse_mode=ParseMode.MARKDOWN_V2
+            )
             await show_main_menu(update, context)
             return MAIN_MENU
         else:
-            await message.reply_text(messages.VACANCY_VERIFICATION_FAILED, parse_mode=ParseMode.MARKDOWN_V2)
-            await message.reply_text(messages.ASK_FOR_VACANCY, reply_markup=keyboards.cancel_keyboard(), parse_mode=ParseMode.MARKDOWN_V2)
+            await message.reply_text(
+                escape_markdown_v2(messages.VACANCY_VERIFICATION_FAILED), parse_mode=ParseMode.MARKDOWN_V2
+            )
+            await message.reply_text(
+                escape_markdown_v2(messages.ASK_FOR_VACANCY),
+                reply_markup=keyboards.cancel_keyboard(),
+                parse_mode=ParseMode.MARKDOWN_V2,
+            )
             return AWAITING_VACANCY_UPLOAD
     finally:
         db.close()
@@ -56,7 +65,11 @@ async def handle_vacancy_file(update: Update, context: ContextTypes.DEFAULT_TYPE
     """Обрабатывает вакансию, загруженную как .txt файл."""
     document = update.message.document
     if not document or not document.file_name.endswith(".txt"):
-        await update.message.reply_text(messages.VACANCY_INVALID_FORMAT, reply_markup=keyboards.cancel_keyboard(), parse_mode=ParseMode.MARKDOWN_V2)
+        await update.message.reply_text(
+            escape_markdown_v2(messages.VACANCY_INVALID_FORMAT),
+            reply_markup=keyboards.cancel_keyboard(),
+            parse_mode=ParseMode.MARKDOWN_V2,
+        )
         return AWAITING_VACANCY_UPLOAD
 
     try:
@@ -64,13 +77,21 @@ async def handle_vacancy_file(update: Update, context: ContextTypes.DEFAULT_TYPE
         file_content_bytes = await file.download_as_bytearray()
     except Exception as e:
         logger.error(f"Ошибка при загрузке файла вакансии: {e}", exc_info=True)
-        await update.message.reply_text(messages.FILE_DOWNLOAD_ERROR, reply_markup=keyboards.cancel_keyboard(), parse_mode=ParseMode.MARKDOWN_V2)
+        await update.message.reply_text(
+            escape_markdown_v2(messages.FILE_DOWNLOAD_ERROR),
+            reply_markup=keyboards.cancel_keyboard(),
+            parse_mode=ParseMode.MARKDOWN_V2,
+        )
         return AWAITING_VACANCY_UPLOAD
 
     try:
         vacancy_text = file_content_bytes.decode("utf-8")
     except UnicodeDecodeError:
-        await update.message.reply_text(messages.FILE_DECODE_ERROR, reply_markup=keyboards.cancel_keyboard(), parse_mode=ParseMode.MARKDOWN_V2)
+        await update.message.reply_text(
+            escape_markdown_v2(messages.FILE_DECODE_ERROR),
+            reply_markup=keyboards.cancel_keyboard(),
+            parse_mode=ParseMode.MARKDOWN_V2,
+        )
         return AWAITING_VACANCY_UPLOAD
 
     return await _process_and_reply(update, context, vacancy_text, source=document.file_name)
@@ -80,12 +101,20 @@ async def handle_vacancy_url(update: Update, context: ContextTypes.DEFAULT_TYPE)
     """Обрабатывает ссылку на вакансию."""
     url = update.message.text
     if "hh.ru" not in url:
-        await update.message.reply_text(messages.VACANCY_INVALID_FORMAT, reply_markup=keyboards.cancel_keyboard(), parse_mode=ParseMode.MARKDOWN_V2)
+        await update.message.reply_text(
+            escape_markdown_v2(messages.VACANCY_INVALID_FORMAT),
+            reply_markup=keyboards.cancel_keyboard(),
+            parse_mode=ParseMode.MARKDOWN_V2,
+        )
         return AWAITING_VACANCY_UPLOAD
 
     vacancy_text = scrape_hh_url(url)
     if not vacancy_text:
-        await update.message.reply_text(messages.ERROR_MESSAGE, reply_markup=keyboards.cancel_keyboard(), parse_mode=ParseMode.MARKDOWN_V2)
+        await update.message.reply_text(
+            escape_markdown_v2(messages.ERROR_MESSAGE),
+            reply_markup=keyboards.cancel_keyboard(),
+            parse_mode=ParseMode.MARKDOWN_V2,
+        )
         return AWAITING_VACANCY_UPLOAD
 
     return await _process_and_reply(update, context, vacancy_text, source=url)
@@ -93,7 +122,11 @@ async def handle_vacancy_url(update: Update, context: ContextTypes.DEFAULT_TYPE)
 
 async def handle_invalid_vacancy_input(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     """Обрабатывает некорректный ввод в состоянии ожидания вакансии."""
-    await update.message.reply_text(messages.VACANCY_INVALID_FORMAT, reply_markup=keyboards.cancel_keyboard(), parse_mode=ParseMode.MARKDOWN_V2)
+    await update.message.reply_text(
+        escape_markdown_v2(messages.VACANCY_INVALID_FORMAT),
+        reply_markup=keyboards.cancel_keyboard(),
+        parse_mode=ParseMode.MARKDOWN_V2,
+    )
     return AWAITING_VACANCY_UPLOAD
 
 # --- Экспортируемые обработчики ---

--- a/bot/utils.py
+++ b/bot/utils.py
@@ -1,0 +1,15 @@
+import re
+
+def escape_markdown_v2(text: str) -> str:
+    """
+    Escapes characters for Telegram's MarkdownV2 parse mode.
+
+    Args:
+        text: The input string.
+
+    Returns:
+        The escaped string.
+    """
+    # In MarkdownV2, characters _, *, [, ], (, ), ~, `, >, #, +, -, =, |, {, }, ., ! must be escaped.
+    escape_chars = r"[_*\[\]()~`>#+\-=|{}.!]"
+    return re.sub(escape_chars, r"\\\g<0>", text)

--- a/tests/test_handlers/test_analysis.py
+++ b/tests/test_handlers/test_analysis.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, MagicMock, patch, mock_open
 
 from bot.handlers import analysis
 from db import models
+from bot.utils import escape_markdown_v2
 
 # Теперь мы можем использовать фикстуры update_mock и context_mock из conftest.py
 
@@ -91,5 +92,7 @@ async def test_perform_analysis_success(
     update_mock.callback_query.message.reply_text.assert_called()
     last_call_args = update_mock.callback_query.message.reply_text.call_args
     # Проверяем, что заголовок из ACTION_REGISTRY и текст ответа AI присутствуют
-    assert "Анализ завершен:" in last_call_args.kwargs['text']
-    assert "This is a test analysis." in last_call_args.kwargs['text']
+    escaped_header = escape_markdown_v2("Анализ завершен:")
+    escaped_body = escape_markdown_v2("This is a test analysis.")
+    assert escaped_header in last_call_args.kwargs['text']
+    assert escaped_body in last_call_args.kwargs['text']

--- a/tests/test_handlers/test_resume.py
+++ b/tests/test_handlers/test_resume.py
@@ -8,6 +8,7 @@ from bot.handlers.resume import (
 )
 from bot.handlers.states import AWAITING_RESUME_UPLOAD, MAIN_MENU
 from bot import messages
+from bot.utils import escape_markdown_v2
 
 # Фикстуры update_mock и context_mock из conftest.py используются неявно
 
@@ -38,7 +39,10 @@ async def test_handle_resume_file_success(
 
     # --- Asserts ---
     mock_process_document.assert_called_once()
-    assert any(messages.RESUME_UPLOADED_SUCCESS in call.args[0] for call in update_mock.message.reply_text.call_args_list)
+    assert any(
+        escape_markdown_v2(messages.RESUME_UPLOADED_SUCCESS) in call.args[0]
+        for call in update_mock.message.reply_text.call_args_list
+    )
     mock_show_main_menu.assert_called_once()
     assert result == MAIN_MENU
 
@@ -69,7 +73,10 @@ async def test_handle_resume_file_failure(
 
     # --- Asserts ---
     mock_process_document.assert_called_once()
-    assert any(messages.RESUME_VERIFICATION_FAILED in call.args[0] for call in update_mock.message.reply_text.call_args_list)
+    assert any(
+        escape_markdown_v2(messages.RESUME_VERIFICATION_FAILED) in call.args[0]
+        for call in update_mock.message.reply_text.call_args_list
+    )
     assert result == AWAITING_RESUME_UPLOAD
 
 
@@ -109,5 +116,5 @@ async def test_handle_invalid_resume_input(update_mock, context_mock):
     result = await handle_invalid_resume_input(update_mock, context_mock)
 
     update_mock.message.reply_text.assert_called_once()
-    assert messages.RESUME_INVALID_FORMAT in update_mock.message.reply_text.call_args.args[0]
+    assert escape_markdown_v2(messages.RESUME_INVALID_FORMAT) in update_mock.message.reply_text.call_args.args[0]
     assert result == AWAITING_RESUME_UPLOAD

--- a/tests/test_handlers/test_start.py
+++ b/tests/test_handlers/test_start.py
@@ -6,6 +6,7 @@ from bot.handlers.start import start
 from bot.handlers.states import AWAITING_RESUME_UPLOAD, AWAITING_VACANCY_UPLOAD, MAIN_MENU
 from db import models
 from bot import messages, keyboards
+from bot.utils import escape_markdown_v2
 
 
 @pytest.mark.anyio
@@ -31,8 +32,12 @@ async def test_start_no_resume(mock_get_db, mock_crud, mock_keyboards, update_mo
     assert result == AWAITING_RESUME_UPLOAD
 
     expected_calls = [
-        call(messages.WELCOME_MESSAGE, parse_mode=ParseMode.MARKDOWN_V2),
-        call(messages.ASK_FOR_RESUME, reply_markup="cancel_keyboard_markup", parse_mode=ParseMode.MARKDOWN_V2)
+        call(escape_markdown_v2(messages.WELCOME_MESSAGE), parse_mode=ParseMode.MARKDOWN_V2),
+        call(
+            escape_markdown_v2(messages.ASK_FOR_RESUME),
+            reply_markup="cancel_keyboard_markup",
+            parse_mode=ParseMode.MARKDOWN_V2,
+        ),
     ]
     update_mock.message.reply_text.assert_has_calls(expected_calls, any_order=False)
 
@@ -63,8 +68,12 @@ async def test_start_with_resume_no_vacancies(mock_get_db, mock_crud, mock_keybo
 
     expected_main_menu_message = messages.MAIN_MENU_NO_VACANCIES.format(resume_title="My Resume Title")
     expected_calls = [
-        call(expected_main_menu_message, parse_mode=ParseMode.MARKDOWN_V2),
-        call(messages.ASK_FOR_VACANCY, reply_markup="cancel_keyboard_markup", parse_mode=ParseMode.MARKDOWN_V2)
+        call(escape_markdown_v2(expected_main_menu_message), parse_mode=ParseMode.MARKDOWN_V2),
+        call(
+            escape_markdown_v2(messages.ASK_FOR_VACANCY),
+            reply_markup="cancel_keyboard_markup",
+            parse_mode=ParseMode.MARKDOWN_V2,
+        ),
     ]
     update_mock.message.reply_text.assert_has_calls(expected_calls, any_order=False)
 

--- a/tests/test_handlers/test_vacancy.py
+++ b/tests/test_handlers/test_vacancy.py
@@ -8,6 +8,7 @@ from bot.handlers.vacancy import (
 )
 from bot.handlers.states import AWAITING_VACANCY_UPLOAD, MAIN_MENU
 from bot import messages
+from bot.utils import escape_markdown_v2
 
 # Фикстуры update_mock и context_mock из conftest.py используются неявно
 
@@ -38,7 +39,10 @@ async def test_handle_vacancy_file_success(
 
     # --- Asserts ---
     mock_process_document.assert_called_once()
-    assert any(messages.VACANCY_UPLOADED_SUCCESS in call.args[0] for call in update_mock.message.reply_text.call_args_list)
+    assert any(
+        escape_markdown_v2(messages.VACANCY_UPLOADED_SUCCESS) in call.args[0]
+        for call in update_mock.message.reply_text.call_args_list
+    )
     mock_show_main_menu.assert_called_once()
     assert result == MAIN_MENU
 
@@ -68,7 +72,10 @@ async def test_handle_vacancy_file_failure(
 
     # --- Asserts ---
     mock_process_document.assert_called_once()
-    assert any(messages.VACANCY_VERIFICATION_FAILED in call.args[0] for call in update_mock.message.reply_text.call_args_list)
+    assert any(
+        escape_markdown_v2(messages.VACANCY_VERIFICATION_FAILED) in call.args[0]
+        for call in update_mock.message.reply_text.call_args_list
+    )
     assert result == AWAITING_VACANCY_UPLOAD
 
 
@@ -107,5 +114,5 @@ async def test_handle_invalid_vacancy_input(update_mock, context_mock):
     result = await handle_invalid_vacancy_input(update_mock, context_mock)
 
     update_mock.message.reply_text.assert_called_once()
-    assert messages.VACANCY_INVALID_FORMAT in update_mock.message.reply_text.call_args.args[0]
+    assert escape_markdown_v2(messages.VACANCY_INVALID_FORMAT) in update_mock.message.reply_text.call_args.args[0]
     assert result == AWAITING_VACANCY_UPLOAD


### PR DESCRIPTION
This change introduces a utility function `escape_markdown_v2` to properly escape special characters in messages sent with `ParseMode.MARKDOWN_V2`.

The function has been applied to all relevant handlers to prevent the bot from crashing due to unescaped characters in user-generated or dynamic content.

The tests have also been updated to reflect these changes and ensure the escaping is working correctly.