### PR TITLE
Fix: Increase max_tokens for AI provider

### DIFF
--- a/ai/providers/gen_api.py
+++ b/ai/providers/gen_api.py
@@ -64,6 +64,7 @@ class GenAPIProvider:
         payload = {
             "model": "gpt-5-mini",
             "messages": [{"role": "user", "content": prompt}],
+            "max_tokens": 8192,
         }
         if is_json:
             payload["response_format"] = {"type": "json_object"}


### PR DESCRIPTION
The consolidated analysis request to the gen-api.ru service was failing with a JSON decoding error. The root cause was that the AI's response was being truncated due to the output length exceeding the default `max_tokens` limit.

This commit fixes the issue by explicitly setting `max_tokens` to 8192 in the request payload within `ai/providers/gen_api.py`. This ensures the AI can return the full JSON object without truncation, resolving the error.