### PR TITLE
Fix: Use Alembic migrations for DB initialization

### DIFF
--- a/db/database.py
+++ b/db/database.py
@@ -1,3 +1,5 @@
+from alembic import command
+from alembic.config import Config
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
@@ -21,10 +23,11 @@ SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 def init_db():
     """
     Инициализирует базу данных.
-    Создает все таблицы, определенные в моделях.
+    Применяет миграции Alembic для обновления схемы до последней версии.
     """
-    # Base.metadata.drop_all(bind=engine) # Раскомментируйте для удаления всех таблиц при перезапуске
-    Base.metadata.create_all(bind=engine)
+    alembic_cfg = Config("alembic.ini")
+    alembic_cfg.set_main_option("sqlalchemy.url", DATABASE_URL)
+    command.upgrade(alembic_cfg, "head")
 
 
 def get_db():


### PR DESCRIPTION
The database was previously initialized using `Base.metadata.create_all()`. This created the tables but did not run any Alembic migrations, leading to missing data that was seeded in a migration (e.g., tariffs).

This change modifies the `init_db` function to run `alembic upgrade head` instead. This ensures that the database schema is always up-to-date and that all data migrations are applied correctly upon application startup.